### PR TITLE
set custom_types to array fixes #28

### DIFF
--- a/rapid-addon.php
+++ b/rapid-addon.php
@@ -1167,7 +1167,7 @@ if (!class_exists('RapidAddon')) {
             }
         }
 
-        public function filter_post_types( $custom_types = '', $custom_type = '' ) {
+        public function filter_post_types( $custom_types = array(), $custom_type = '' ) {
             $options = $this->options_array();
             $option_key = 'post_types_to_remove';
 


### PR DESCRIPTION
Set $custom_types to an empty array by default. An array is expected by other filter functions.