### PR TITLE
Replace is_plugin_active conditional checks for WP All Import with class_exists

### DIFF
--- a/rapid-addon.php
+++ b/rapid-addon.php
@@ -75,7 +75,7 @@ if (!class_exists('RapidAddon')) {
 
 		function is_active_addon($post_type = null) {
 			
-			if ( ! is_plugin_active('wp-all-import-pro/wp-all-import-pro.php') and ! is_plugin_active('wp-all-import/plugin.php') ){
+			if ( ! class_exists( 'PMXI_Plugin' ) ) {
 				return false;
 			}
 

--- a/rapid-addon.php
+++ b/rapid-addon.php
@@ -1116,7 +1116,7 @@ if (!class_exists('RapidAddon')) {
 
 			include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
-			if ( ! is_plugin_active('wp-all-import-pro/wp-all-import-pro.php') and ! is_plugin_active('wp-all-import/plugin.php') ){
+			if ( ! class_exists( 'PMXI_Plugin' ) ) {
 				$is_show_notice = true;
 			}
 


### PR DESCRIPTION
This is part of my previous PR that is about moving the library closer to a Composer-friendly package. If you are loading WP All Import and related plugins with Composer, say with wpackagist, WordPress does not recognize it as an active_plugin. SO by removing this `is_plugin_active` conditional check and using a `class_exists`, we can load this library and WP All Import side by side. 